### PR TITLE
Fix file left open issue that breaks glassfish V5 build on Windows 10.

### DIFF
--- a/src/main/java/org/glassfish/module/maven/commandsecurityplugin/TypeProcessorImpl.java
+++ b/src/main/java/org/glassfish/module/maven/commandsecurityplugin/TypeProcessorImpl.java
@@ -675,6 +675,7 @@ public class TypeProcessorImpl implements TypeProcessor {
             }
             result.add(inhabitant);
         }
+        br.close();
         return result;
     }
     


### PR DESCRIPTION
Glassfish subproject HK2 configuration module fails to build on 2nd invocation because "glassfish\nucleus\hk2\hk2-config\target\classes\META-INF\hk2-locator\default" file is still open.